### PR TITLE
Removed README.md exclusion from .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -22,7 +22,6 @@
 **/secrets.dev.yaml
 **/values.dev.yaml
 LICENSE
-README.md
 !**/.gitignore
 !.git/HEAD
 !.git/config


### PR DESCRIPTION
Removed README.md exclusion from .dockerignore to enable Azure Devops onboarding.