### PR TITLE
Fix/array serialization problem

### DIFF
--- a/source/Cute.Lib/Scriban/CuteFunctions.cs
+++ b/source/Cute.Lib/Scriban/CuteFunctions.cs
@@ -231,7 +231,9 @@ public class CuteFunctions : ScriptObject
 
         var contentEntries = GetFromLookupCache(contentType, matchField, cacheKey);
 
-        var lookupValues = values.Split(',').Select(s => s.Trim()).Select(s => contentEntries.ContainsKey(s) ? s : defaultValue);
+        var lookupValues = values.Split(',')
+            .Select(s => s.Trim())
+            .Select(s => contentEntries.ContainsKey(s) ? s : defaultValue);
 
         var resultValues = returnField.Equals("$id", StringComparison.OrdinalIgnoreCase)
             ? lookupValues.Select(s => contentEntries[s].SystemProperties.Id)


### PR DESCRIPTION
- ensure that delimiter for creating flat arrays "|" also supports ","
- fixes bug where contentful string arrays delimit by ","
- "|" takes presedence over ","
- To differentiate a string with "," and array, does a quick and deep JArray element count comparison on new and cloud entries
- Mainly affects Field Serialization and Upsert logic