### PR TITLE
Append fields during upsert in sync-api command

### DIFF
--- a/source/Cute/Commands/Content/ContentSyncApiCommand.cs
+++ b/source/Cute/Commands/Content/ContentSyncApiCommand.cs
@@ -87,7 +87,7 @@ public class ContentSyncApiCommand(IConsoleWriter console, ILogger<ContentSyncAp
 
         var bulkOperations = new List<IBulkAction>()
         {
-            new UpsertBulkAction(ContentfulConnection, _httpClient)
+            new UpsertBulkAction(ContentfulConnection, _httpClient, true)
                 .WithContentType(contentType)
                 .WithContentLocales(contentLocales)
                 .WithNewEntries(


### PR DESCRIPTION
- Allow appending fields in sync-api so that new values for localized fields don't get filtered out