### PR TITLE
Fixed command description for large/huge cities

### DIFF
--- a/source/Cute/Commands/Content/ContentSeedGeoDataCommand.cs
+++ b/source/Cute/Commands/Content/ContentSeedGeoDataCommand.cs
@@ -71,7 +71,7 @@ public sealed class ContentSeedGeoDataCommand(IConsoleWriter console, ILogger<Co
         public int LargePopulation { get; set; } = 10000;
 
         [CommandOption("-h|--huge-population")]
-        [Description("The city or town minimum population for large cities")]
+        [Description("The city or town minimum population for huge cities")]
         public int HugePopulation { get; set; } = 40000;
 
         [CommandOption("-a|--apply")]


### PR DESCRIPTION
- Fixed description for `cute content seed-geo` command option `-h|--huge-population` to reflect 'huge' city and not 'large' city