### PR TITLE
Update Content seed-geo -h command description

### DIFF
--- a/source/Cute/Commands/Content/ContentSeedGeoDataCommand.cs
+++ b/source/Cute/Commands/Content/ContentSeedGeoDataCommand.cs
@@ -67,11 +67,11 @@ public sealed class ContentSeedGeoDataCommand(IConsoleWriter console, ILogger<Co
         public int SmallKilometerRadius { get; set; } = 2;
 
         [CommandOption("-n|--large-population")]
-        [Description("The city or town minimum population for large cities")]
+        [Description("The minimum population for a city or town to be considered large in scale")]
         public int LargePopulation { get; set; } = 10000;
 
         [CommandOption("-h|--huge-population")]
-        [Description("The city or town minimum population for large cities")]
+        [Description("The minimum population for a city or town to be considered huge in scale")]
         public int HugePopulation { get; set; } = 40000;
 
         [CommandOption("-a|--apply")]


### PR DESCRIPTION
- Fixed description for `cute content seed-geo` command option -`h|--huge-population` to reflect 'huge' city and not 'large' city