### PR TITLE
add glossary to translation

### DIFF
--- a/source/Cute.Lib/Contentful/CommandModels/TranslationGlossary/CuteTranslationContentType.cs
+++ b/source/Cute.Lib/Contentful/CommandModels/TranslationGlossary/CuteTranslationContentType.cs
@@ -1,0 +1,37 @@
+﻿using Contentful.Core.Models;
+using Contentful.Core.Search;
+using Cute.Lib.Enums;
+
+namespace Cute.Lib.Contentful.CommandModels.Schedule
+{
+    public class CuteTranslationContentType
+    {
+        private static readonly ContentType _contentType;
+
+        public static ContentType Instance()
+        {
+            return _contentType;
+        }
+
+        static CuteTranslationContentType()
+        {
+            var contentTypeBuilder = new ContentTypeBuilder(nameof(CuteTranslationContentType).ToCamelCase())
+                .WithDescription("Glossary for translations.")
+                .WithDisplayField("title")
+                .WithFields([
+
+                    new FieldBuilder("key", FieldType.Symbol)
+                    .IsRequired()
+                    .IsUnique()
+                    .Build(),
+
+                    new FieldBuilder("title", FieldType.Text)
+                        .IsUnique()
+                        .Build()
+
+                ]);
+
+            _contentType = contentTypeBuilder.Build();
+        }
+    }
+}

--- a/source/Cute.Lib/Contentful/CommandModels/TranslationGlossary/CuteTranslationGlossary.cs
+++ b/source/Cute.Lib/Contentful/CommandModels/TranslationGlossary/CuteTranslationGlossary.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Cute.Lib.Contentful.CommandModels.TranslationGlossary
+{
+    public class CuteTranslationGlossary
+    {
+        public Dictionary<string, string> Key { get; set; } = default!;
+        public Dictionary<string, string> Title { get; set; } = default!;
+    }
+}

--- a/source/Cute/Services/Translation/AzureTranslator.cs
+++ b/source/Cute/Services/Translation/AzureTranslator.cs
@@ -26,7 +26,7 @@ public class AzureTranslator : ITranslator
         _httpClient = httpClient;
     }
 
-    public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode)
+    public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, Dictionary<string, string>? glossary = null)
     {
         var result = await Translate(fromLanguageCode, [toLanguageCode], textToTranslate);
 
@@ -47,7 +47,7 @@ public class AzureTranslator : ITranslator
         }).ToArray();
     }
 
-    public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation)
+    public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null)
     {
         return await Translate(textToTranslate, fromLanguageCode, toLanguageCode);
     }
@@ -62,7 +62,7 @@ public class AzureTranslator : ITranslator
         throw new NotImplementedException();
     }
 
-    public async Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage)
+    public async Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, Dictionary<string, string>? glossary = null)
     {
         if (string.IsNullOrEmpty(toLanguage.TranslationContext))
         {
@@ -78,7 +78,7 @@ public class AzureTranslator : ITranslator
         }).FirstOrDefault();
     }
 
-    public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation)
+    public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null)
     {
         throw new NotImplementedException();
     }

--- a/source/Cute/Services/Translation/DeeplTranslator.cs
+++ b/source/Cute/Services/Translation/DeeplTranslator.cs
@@ -30,7 +30,7 @@ namespace Cute.Services.Translation
             return results.ToArray();
         }
 
-        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode)
+        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, Dictionary<string, string>? glossary = null)
         {
             var result = await _translator.TranslateTextAsync(textToTranslate, fromLanguageCode, toLanguageCode);
             return new TranslationResponse
@@ -40,7 +40,7 @@ namespace Cute.Services.Translation
             };
         }
 
-        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation)
+        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null)
         {
             return await Translate(textToTranslate, fromLanguageCode, toLanguageCode);
         }
@@ -55,12 +55,12 @@ namespace Cute.Services.Translation
             throw new NotImplementedException();
         }
 
-        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage)
+        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, Dictionary<string, string>? glossary = null)
         {
             throw new NotImplementedException();
         }
 
-        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation)
+        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null)
         {
             throw new NotImplementedException();
         }

--- a/source/Cute/Services/Translation/GoogleTranslator.cs
+++ b/source/Cute/Services/Translation/GoogleTranslator.cs
@@ -31,7 +31,7 @@ namespace Cute.Services.Translation
             return results.ToArray();
         }
 
-        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode)
+        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, Dictionary<string, string>? glossary = null)
         {
             var result = await _client.TranslateTextAsync(textToTranslate, toLanguageCode, fromLanguageCode);
             return new TranslationResponse
@@ -41,7 +41,7 @@ namespace Cute.Services.Translation
             };
         }
 
-        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation)
+        public async Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null)
         {
             return await Translate(textToTranslate, fromLanguageCode, toLanguageCode);
         }
@@ -56,12 +56,12 @@ namespace Cute.Services.Translation
             throw new NotImplementedException();
         }
 
-        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage)
+        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, Dictionary<string, string>? glossary = null)
         {
             throw new NotImplementedException();
         }
 
-        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation)
+        public Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null)
         {
             throw new NotImplementedException();
         }

--- a/source/Cute/Services/Translation/Interfaces/ITranslator.cs
+++ b/source/Cute/Services/Translation/Interfaces/ITranslator.cs
@@ -6,10 +6,12 @@ namespace Cute.Services.Translation.Interfaces
     {
         Task<TranslationResponse[]?> Translate(string textToTranslate, string fromLanguageCode, IEnumerable<string> toLanguageCodes);
         Task<TranslationResponse[]?> Translate(string textToTranslate, string fromLanguageCode, IEnumerable<string> toLanguageCodes, CuteContentTypeTranslation? cuteContentTypeTranslation);
-        Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode);
-        Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation);
+        Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, Dictionary<string, string>? glossary = null);
+        Task<TranslationResponse?> Translate(string textToTranslate, string fromLanguageCode, string toLanguageCode, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null);
         Task<TranslationResponse[]?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, IEnumerable<CuteLanguage> toLanguages);
-        Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation);
+
+        Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, Dictionary<string, string>? glossary = null);
+        Task<TranslationResponse?> TranslateWithCustomModel(string textToTranslate, string fromLanguageCode, CuteLanguage toLanguage, CuteContentTypeTranslation? cuteContentTypeTranslation, Dictionary<string, string>? glossary = null);
     }
 
     public class TranslationResponse


### PR DESCRIPTION
- add cuteTranslationGlossary content type to be used for more precise translations
- add new optional parameter to translation command --use-glossary (default is false)