### PR TITLE
Upgrade project and packages/dependencies to .Net 9

### DIFF
--- a/.github/workflows/cute-cd.yaml
+++ b/.github/workflows/cute-cd.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.0.x']
+        dotnet-version: ['9.x']
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/cute-ci.yaml
+++ b/.github/workflows/cute-ci.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: ['8.x']
+        dotnet-version: ['9.x']
 
     steps:
       - uses: actions/checkout@v4

--- a/source/Cute.Lib/Cute.Lib.csproj
+++ b/source/Cute.Lib/Cute.Lib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 	<RootNamespace>Cute.Lib</RootNamespace>
     <Nullable>enable</Nullable>
@@ -9,27 +9,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.AI.OpenAI" Version="2.0.0" />
-    <PackageReference Include="Bogus" Version="35.6.1" />
-    <PackageReference Include="ClosedXML" Version="0.104.1" />
-    <PackageReference Include="contentful.csharp" Version="8.3.0" />
-    <PackageReference Include="CsvHelper" Version="33.0.1" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="2.1.0" />
+    <PackageReference Include="Bogus" Version="35.6.3" />
+    <PackageReference Include="ClosedXML" Version="0.105.0" />
+    <PackageReference Include="contentful.csharp" Version="8.4.1" />
+    <PackageReference Include="CsvHelper" Version="33.1.0" />
     <PackageReference Include="dotenv.net" Version="3.2.1" />
     <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="GraphQL-Parser" Version="9.5.0" />
-    <PackageReference Include="Html2Markdown" Version="7.0.1.9" />
+    <PackageReference Include="Html2Markdown" Version="7.0.5.14" />
     <PackageReference Include="NCrontab.Scheduler.AspNetCore" Version="1.2.10" />
     <PackageReference Include="Nox.Cron" Version="8.0.5" />
-    <PackageReference Include="scriban" Version="5.10.0" />
-    <PackageReference Include="Serilog" Version="4.0.2" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="8.0.0" />
+    <PackageReference Include="scriban" Version="6.2.1" />
+    <PackageReference Include="Serilog" Version="4.3.0" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.1.1" />
-    <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <PackageReference Include="Serilog.Sinks.OpenTelemetry" Version="4.2.0" />
+    <PackageReference Include="SharpCompress" Version="0.40.0" />
     <PackageReference Include="SharpZipLib" Version="1.4.2" />
-    <PackageReference Include="System.IO.Hashing" Version="8.0.0" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.6" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
-    <PackageReference Include="YamlDotNet" Version="16.1.3" />
+    <PackageReference Include="YamlDotNet" Version="16.3.0" />
   </ItemGroup>
 
 </Project>

--- a/source/Cute/Cute.csproj
+++ b/source/Cute/Cute.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net9.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<RootNamespace>Cute</RootNamespace>
@@ -34,19 +34,19 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageReference Include="ColorfulCode" Version="1.0.0-preview1" />
-		<PackageReference Include="DeepL.net" Version="1.10.0" />
+		<PackageReference Include="DeepL.net" Version="1.15.0" />
 		<PackageReference Include="Google.Cloud.Translation.V2" Version="3.4.0" />
-		<PackageReference Include="Markdig" Version="0.37.0" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.0-rc.1.24452.1" />
-		<PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="9.0.0-rc.1.24452.1" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0-rc.1.24431.7" />
-		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.0" />
+		<PackageReference Include="Markdig" Version="0.41.2" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="9.0.6" />
+		<PackageReference Include="Microsoft.AspNetCore.DataProtection.Extensions" Version="9.0.6" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.6" />
+		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
 		<PackageReference Include="Nox.Cron" Version="8.0.5" />
-		<PackageReference Include="Spectre.Console" Version="0.49.2-preview.0.44" />
-		<PackageReference Include="Spectre.Console.Cli" Version="0.49.2-preview.0.44" />
-		<PackageReference Include="Spectre.Console.ImageSharp" Version="0.49.2-preview.0.44" />
+		<PackageReference Include="Spectre.Console" Version="0.50.0" />
+		<PackageReference Include="Spectre.Console.Cli" Version="0.50.0" />
+		<PackageReference Include="Spectre.Console.ImageSharp" Version="0.50.0" />
 		<PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
-		<PackageReference Include="System.Formats.Asn1" Version="9.0.0-rc.1.24431.7" />
+		<PackageReference Include="System.Formats.Asn1" Version="9.0.6" />
 	</ItemGroup>
 	<ItemGroup>
 	  <ProjectReference Include="..\Cute.Lib\Cute.Lib.csproj" />

--- a/tests/Cute.Unit.Tests/Cute.Unit.Tests.csproj
+++ b/tests/Cute.Unit.Tests/Cute.Unit.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -10,14 +10,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.2">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="FluentAssertions" Version="6.12.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="xunit" Version="2.9.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="FluentAssertions" Version="6.12.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request updates the target framework across multiple projects to `net9.0` and upgrades several package dependencies to their latest versions. These changes ensure compatibility with the new framework and improve functionality by incorporating the latest features and bug fixes.

### Framework Updates:
* Updated the `TargetFramework` property in `Cute.Lib.csproj`, `Cute.csproj`, and `Cute.Unit.Tests.csproj` from `net8.0` to `net9.0`. [[1]](diffhunk://#diff-8e3ff9e1d4c370d2eb601caaa41cbd55711efe5957d34e5351f55f409dc9e8a4L4-R32) [[2]](diffhunk://#diff-66da46953cc75fd9d4a84ab07a54606711be6135563a5c52a125317bc3309bfaL4-R4) [[3]](diffhunk://#diff-8c61fe70f497a64ed022abb385ce120da2642d96cbf91066cd47db3f2973e8e3L4-R4)

### Dependency Updates:
#### Core Library (`Cute.Lib`):
* Upgraded multiple package dependencies, including `Azure.AI.OpenAI` to `2.1.0`, `Serilog` to `4.3.0`, and `SharpCompress` to `0.40.0`.

#### Application (`Cute`):
* Updated packages such as `DeepL.net` to `1.15.0`, `Markdig` to `0.41.2`, and `Spectre.Console` to `0.50.0`.

#### Unit Tests (`Cute.Unit.Tests`):
* Upgraded testing-related packages, including `coverlet.collector` to `6.0.4`, `FluentAssertions` to `6.12.2`, and `xunit` to `2.9.3`.